### PR TITLE
Add inexact match, review_status and term reliability table

### DIFF
--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -866,6 +866,15 @@ def annotation_info(annotationid):
 
     webPage += draw_flag_annotation_button(annotationid)
 
+    webPage += '<h2>Review status</h2>'
+    review_status = annotation.get('review_status', -1)
+    if review_status == 0:
+        webPage += '<br>Pending review (annotation has not been reviewed yet by the dbBact team)<br>'
+    elif review_status == 1:
+        webPage += '<br>Accepted (annotation has been reviewed by the dbBact team and accepted)<br>'
+    else:
+        webPage += '<br>NA<br>'
+
     webPage += '<h2>Sequences</h2>'
     webPage += draw_download_fasta_button(annotationid)
 

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -768,7 +768,7 @@ def draw_sequences_annotations_compact(seqs, ignore_exp=[], draw_only_details=Fa
         webPage += '<h2>No exact match found</h2> Annotations are for %d sequences with inexact match<br><br>' % len(seqs)
         seqs_details = []
         for cseq in seqs:
-            seqs_details.append('<tr><a href=%s target="_blank">%s</a></tr>' % (url_for('.sequence', sequence=cseq), cseq))
+            seqs_details.append('<tr><a href=%s target="_blank">%s</a></tr>' % (url_for('.sequence_annotations', sequence=cseq),  Markup.escape(cseq)))
         webPage += render_template('seq-list-collapse.html', seq_count=len(seqs), details=seqs_details)
     webPage += draw_group_annotation_details(annotations, seqannotations, term_info=term_info, ignore_exp=ignore_exp, sequences=seqs)
     if not draw_only_details:

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -768,7 +768,7 @@ def draw_sequences_annotations_compact(seqs, ignore_exp=[], draw_only_details=Fa
         webPage += '<h2>No exact match found</h2> Annotations are for %d sequences with inexact match<br><br>' % len(seqs)
         seqs_details = ''
         for cseq in seqs:
-            seqs_details += ('<tr><a href=%s target="_blank">%s</a></tr>' % (url_for('.sequence_annotations', sequence=cseq),  Markup.escape(cseq)))
+            seqs_details += ('<tr><td><a href=%s target="_blank">%s</a></td></tr>' % (url_for('.sequence_annotations', sequence=cseq),  Markup.escape(cseq)))
         webPage += render_template('seq-list-collapse.html', title='Inexact match sequences', seq_count=len(seqs), details=seqs_details)
     webPage += draw_group_annotation_details(annotations, seqannotations, term_info=term_info, ignore_exp=ignore_exp, sequences=seqs)
     if not draw_only_details:

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -2379,7 +2379,7 @@ def draw_group_annotation_details(annotations, seqannotations, term_info, includ
     wpart += cpart
     tterms.update(cterm for cterm,score in tscores)
     # add the term count tab, only for the terms listed in the fscore/precision/recall parts
-    cpart, tscores += draw_ontology_score_list(term_count, section_id='term_count', description='Number of experiments containing the term',term_set=tterms)
+    cpart, tscores = draw_ontology_score_list(term_count, section_id='term_count', description='Number of experiments containing the term',term_set=tterms)
     wpart += cpart
 
     # draw the annotation table

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -601,6 +601,11 @@ def sequence_annotations(sequence):
     webPage = render_header(title='dbBact sequence annotation')
     webPage += render_template('seqinfo.html', sequence=sequence.upper(), taxonomy=taxStr, species_details=species_details, num_species_match=num_species_match)
 
+    if found_only_mismatch:
+        webPage += '<h2>Exact sequence was not found in dbBact</h2>'
+        webPage += '<p>However, a single sequence with a high similarity to your sequence was found in dbBact. '
+        webPage += 'Showing results for this sequence</p>'
+
     if show_trim_msg:
         if found_seq:
             webPage += '<h2>Sequence found after trimming primers: %s</h2>' % trim_msg

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -554,9 +554,9 @@ def sequence_annotations(sequence):
             found_only_mismatch = True
             found_seq = True
             if len(close_seqs) > 1:
-                close_seqs = [cseq['sequence'] for cseq in close_seqs]
                 num_mismatches = [cseq['num_mismatches'] for cseq in close_seqs]
-                err, webpage = draw_sequences_annotations_compact(close_seqs, inexact_match=True, num_mismatches=num_mismatches)
+                seqs = [cseq['sequence'] for cseq in close_seqs]
+                err, webpage = draw_sequences_annotations_compact(seqs, inexact_match=True, num_mismatches=num_mismatches)
                 return webpage
             else:
                 sequence = close_seqs[0]['sequence']
@@ -2689,7 +2689,7 @@ def get_close_sequences(sequence, max_mismatches = 2):
     if httpResTax.status_code == requests.codes.ok:
         res = httpResTax.json()
         debug(2, 'Found %d close sequences' % len(res['similar_seqs']))
-        debug(2, str(res['similar_seqs']))
+        debug(1, str(res['similar_seqs']))
         return res['similar_seqs']
     debug('error encountered when trying to get close sequences for sequence %s' % sequence)
     return []

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -765,10 +765,10 @@ def draw_sequences_annotations_compact(seqs, ignore_exp=[], draw_only_details=Fa
     if not inexact_match:
         webPage += '<h2>Annotations for %d sequences</h2>' % len(seqs)
     else:
-        webPage += '<h2>No exact match found</h2> Annotations are for %d sequences with inexact match<br><br>' % len(seqs)
+        webPage += '<h2>No exact match found</h2>' % len(seqs)
         seqs_details = ''
         for cseq in seqs:
-            seqs_details += ('<tr><td><a href=%s target="_blank">%s</a></td></tr>' % (url_for('.sequence_annotations', sequence=cseq),  Markup.escape(cseq)))
+            seqs_details += ('<tr><td><a href=%s target="_blank">%s</a></td></tr>' % (url_for('.sequence_annotations', sequence=cseq),  Markup.escape(cseq.upper())))
         webPage += render_template('seq-list-collapse.html', title='Inexact match sequences', seq_count=len(seqs), details=seqs_details)
     webPage += draw_group_annotation_details(annotations, seqannotations, term_info=term_info, ignore_exp=ignore_exp, sequences=seqs)
     if not draw_only_details:

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -2364,6 +2364,7 @@ def draw_group_annotation_details(annotations, seqannotations, term_info, includ
     wpart += draw_ontology_score_list(fscores, section_id='fscores', description='term enrichment score')
     wpart += draw_ontology_score_list(recall, section_id='recall', description='Fraction of dbbact annotations with this term covered by the query')
     wpart += draw_ontology_score_list(precision, section_id='precision', description='Fraction of annotations for the query sequences containing the term')
+    wpart += draw_ontology_score_list(term_count, section_id='term_count', description='Number of experiments containing the term')
 
     # draw the annotation table
     # first we need to sort the annotations by total sequences from submitted list in each annotation

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -2058,9 +2058,11 @@ def _get_color(word, font_size, position, orientation, font_path, random_state, 
     if word[0] == '-':
         cmap = mpl.cm.get_cmap('Oranges')
         rgba = cmap(float(0.4 + count / 40), bytes=True)
+        rgba = cmap(float(0.3 + count / 20), bytes=True)
     else:
         cmap = mpl.cm.get_cmap('Purples')
         rgba = cmap(float(0.4 + count / 40), bytes=True)
+        rgba = cmap(float(0.3 + count / 20), bytes=True)
 
     red = format(rgba[0], '02x')
     green = format(rgba[1], '02x')

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -2689,6 +2689,7 @@ def get_close_sequences(sequence, max_mismatches = 2):
     if httpResTax.status_code == requests.codes.ok:
         res = httpResTax.json()
         debug(2, 'Found %d close sequences' % len(res['similar_seqs']))
+        debug(2, str(res['similar_seqs']))
         return res['similar_seqs']
     debug('error encountered when trying to get close sequences for sequence %s' % sequence)
     return []

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -2379,7 +2379,7 @@ def draw_group_annotation_details(annotations, seqannotations, term_info, includ
     wpart += cpart
     tterms.update(cterm for cterm,score in tscores)
     # add the term count tab, only for the terms listed in the fscore/precision/recall parts
-    cpart, tscores = draw_ontology_score_list(term_count, section_id='term_count', description='Number of experiments containing the term',term_set=tterms)
+    cpart, tscores = draw_ontology_score_list(term_count, section_id='term_count', description='Number of experiments containing the term',term_set=tterms, max_terms=None)
     wpart += cpart
 
     # draw the annotation table

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -766,10 +766,10 @@ def draw_sequences_annotations_compact(seqs, ignore_exp=[], draw_only_details=Fa
         webPage += '<h2>Annotations for %d sequences</h2>' % len(seqs)
     else:
         webPage += '<h2>No exact match found</h2> Annotations are for %d sequences with inexact match<br><br>' % len(seqs)
-        seqs_details = []
+        seqs_details = ''
         for cseq in seqs:
-            seqs_details.append('<tr><a href=%s target="_blank">%s</a></tr>' % (url_for('.sequence_annotations', sequence=cseq),  Markup.escape(cseq)))
-        webPage += render_template('seq-list-collapse.html', seq_count=len(seqs), details=seqs_details)
+            seqs_details += ('<tr><a href=%s target="_blank">%s</a></tr>' % (url_for('.sequence_annotations', sequence=cseq),  Markup.escape(cseq)))
+        webPage += render_template('seq-list-collapse.html', title='Inexact match sequences', seq_count=len(seqs), details=seqs_details)
     webPage += draw_group_annotation_details(annotations, seqannotations, term_info=term_info, ignore_exp=ignore_exp, sequences=seqs)
     if not draw_only_details:
         webPage += render_template('footer.html')

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -1963,6 +1963,9 @@ def draw_ontology_score_list(scores, section_id, description=None, max_terms=100
         data = [x for x in data if x[0] in term_set]
 
     for cterm, cscore in data:
+        if len(cterm) == 0:
+            debug(3, 'Empty term in ontology score list')
+            continue
         if cterm[0] == '-':
             ctermlink = cterm[1:]
             cterm = 'LOWER IN %s' % Markup.escape(ctermlink)

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -1817,10 +1817,6 @@ def draw_annotation_table(annotations, include_ratio=True):
     -------
     str: the HTML part for the annotations table
     '''
-    # wpart = '<div id="annot-table" class="tab-pane in active" style="margin-top: 20px; margin-bottom: 20px;">\n'
-
-    # the table header and css
-    # wpart += render_template('annottable.html')
     wpart = ''
     for dataRow in annotations:
         wpart += '  <tr>'
@@ -1844,13 +1840,6 @@ def draw_annotation_table(annotations, include_ratio=True):
         # add the annotation region
         wpart += '<td>%s</td>' % Markup.escape(dataRow['primer'])
 
-        # add the number of flags
-        if len(dataRow['flags']) > 0:
-            flags = '%s' % len(dataRow['flags'])
-        else:
-            flags = 'No'
-        wpart += '<td>%s</td>' % Markup.escape(flags)
-
         # add the sequences
         annotationid = dataRow.get('annotationid', -1)
         num_sequences = dataRow.get('num_sequences', '?')
@@ -1864,6 +1853,24 @@ def draw_annotation_table(annotations, include_ratio=True):
             observed_sequences = '?'
             sequences_string = '%s' % num_sequences
         wpart += "<td><a href=%s>%s</a></td>" % (url_for('.annotation_seqs', annotationid=annotationid), Markup.escape(sequences_string))
+
+        # add the annotation review status
+        review_status = dataRow.get('review_status', -1)
+        if review_status == 0:
+            review_status_str = 'pending'
+        elif review_status == 1:
+            review_status_str = 'approved'
+        else:
+            review_status_str = 'NA'
+        wpart += '<td>%s</td>' % Markup.escape(review_status_str)
+
+        # add the number of flags
+        if len(dataRow['flags']) > 0:
+            flags = '%s' % len(dataRow['flags'])
+        else:
+            flags = 'No'
+        wpart += '<td>%s</td>' % Markup.escape(flags)
+
         wpart += '</tr>\n'
     # wpart += '</table>\n'
     # wpart += '</div>\n'

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -765,7 +765,7 @@ def draw_sequences_annotations_compact(seqs, ignore_exp=[], draw_only_details=Fa
     if not inexact_match:
         webPage += '<h2>Annotations for %d sequences</h2>' % len(seqs)
     else:
-        webPage += '<h2>No exact match found</h2>' % len(seqs)
+        webPage += '<h2>No exact match found</h2>'
         seqs_details = ''
         for cseq in seqs:
             seqs_details += ('<tr><td><a href=%s target="_blank">%s</a></td></tr>' % (url_for('.sequence_annotations', sequence=cseq),  Markup.escape(cseq.upper())))

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -766,6 +766,10 @@ def draw_sequences_annotations_compact(seqs, ignore_exp=[], draw_only_details=Fa
         webPage += '<h2>Annotations for %d sequences</h2>' % len(seqs)
     else:
         webPage += '<h2>No exact match found</h2> Annotations are for %d sequences with inexact match<br><br>' % len(seqs)
+        seqs_details = []
+        for cseq in seqs:
+            seqs_details.append('<tr><a href=%s target="_blank">%s</a></tr>' % (url_for('.sequence', sequence=cseq), cseq))
+        webPage += render_template('seq-list-collapse.html', seq_count=len(seqs), details=seqs_details)
     webPage += draw_group_annotation_details(annotations, seqannotations, term_info=term_info, ignore_exp=ignore_exp, sequences=seqs)
     if not draw_only_details:
         webPage += render_template('footer.html')

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -554,7 +554,7 @@ def sequence_annotations(sequence):
             found_only_mismatch = True
             found_seq = True
             if len(close_seqs) > 1:
-                err, webpage = draw_sequences_annotations_compact(close_seqs)
+                err, webpage = draw_sequences_annotations_compact(close_seqs, inexact_match=True)
                 return webpage
             else:
                 sequence = close_seqs[0]
@@ -718,7 +718,7 @@ def draw_sequences_annotations(seqs):
     return '', webPage
 
 
-def draw_sequences_annotations_compact(seqs, ignore_exp=[], draw_only_details=False):
+def draw_sequences_annotations_compact(seqs, ignore_exp=[], draw_only_details=False, inexact_match=False):
     '''Draw the webpage for annotations for a set of sequences
 
     Parameters
@@ -729,6 +729,8 @@ def draw_sequences_annotations_compact(seqs, ignore_exp=[], draw_only_details=Fa
     draw_only_details: bool, optional
         True to plot only the annotations part (no header/footer)
         False to draw complete page
+    inexact_match: bool, optional
+        If True, results are for inexact matches to a given original sequence
 
 
     Returns
@@ -760,7 +762,10 @@ def draw_sequences_annotations_compact(seqs, ignore_exp=[], draw_only_details=Fa
         webPage = ''
     else:
         webPage = render_header()
-    webPage += '<h2>Annotations for %d sequences</h2>' % len(seqs)
+    if not inexact_match:
+        webPage += '<h2>Annotations for %d sequences</h2>' % len(seqs)
+    else:
+        webPage += '<h2>No exact match found</h2> Annotations are for %d sequences with inexact match<br><br>' % len(seqs)
     webPage += draw_group_annotation_details(annotations, seqannotations, term_info=term_info, ignore_exp=ignore_exp, sequences=seqs)
     if not draw_only_details:
         webPage += render_template('footer.html')

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -2384,7 +2384,7 @@ def draw_group_annotation_details(annotations, seqannotations, term_info, includ
     wpart += cpart
     tterms.update(cterm for cterm,score in tscores)
     # add the term count tab, only for the terms listed in the fscore/precision/recall parts
-    cpart, tscores = draw_ontology_score_list(term_count, section_id='term_count', description='Number of experiments containing the term',term_set=tterms, max_terms=None)
+    cpart, tscores = draw_ontology_score_list(term_count, section_id='term_count', description='Number of experiments associating the term to the sequence',term_set=tterms, max_terms=None)
     wpart += cpart
 
     # draw the annotation table

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -2369,13 +2369,13 @@ def draw_group_annotation_details(annotations, seqannotations, term_info, includ
     wpart += render_template('tabs.html')
 
     tterms = set()
-    cpart, tscores += draw_ontology_score_list(fscores, section_id='fscores', description='term enrichment score')
+    cpart, tscores = draw_ontology_score_list(fscores, section_id='fscores', description='term enrichment score')
     wpart += cpart
     tterms.update(cterm for cterm,score in tscores)
-    cpart, tscores += draw_ontology_score_list(recall, section_id='recall', description='Fraction of dbbact annotations with this term covered by the query')
+    cpart, tscores = draw_ontology_score_list(recall, section_id='recall', description='Fraction of dbbact annotations with this term covered by the query')
     wpart += cpart
     tterms.update(cterm for cterm,score in tscores)
-    cpart, tscores += draw_ontology_score_list(precision, section_id='precision', description='Fraction of annotations for the query sequences containing the term')
+    cpart, tscores = draw_ontology_score_list(precision, section_id='precision', description='Fraction of annotations for the query sequences containing the term')
     wpart += cpart
     tterms.update(cterm for cterm,score in tscores)
     # add the term count tab, only for the terms listed in the fscore/precision/recall parts

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -2369,11 +2369,14 @@ def draw_group_annotation_details(annotations, seqannotations, term_info, includ
     wpart += render_template('tabs.html')
 
     tterms = set()
-    wpart, tscores += draw_ontology_score_list(fscores, section_id='fscores', description='term enrichment score')
+    cpart, tscores += draw_ontology_score_list(fscores, section_id='fscores', description='term enrichment score')
+    wpart += cpart
     tterms.update(cterm for cterm,score in tscores)
-    wpart, tscores += draw_ontology_score_list(recall, section_id='recall', description='Fraction of dbbact annotations with this term covered by the query')
+    cpart, tscores += draw_ontology_score_list(recall, section_id='recall', description='Fraction of dbbact annotations with this term covered by the query')
+    wpart += cpart
     tterms.update(cterm for cterm,score in tscores)
-    wpart, tscores += draw_ontology_score_list(precision, section_id='precision', description='Fraction of annotations for the query sequences containing the term')
+    cpart, tscores += draw_ontology_score_list(precision, section_id='precision', description='Fraction of annotations for the query sequences containing the term')
+    wpart += cpart
     tterms.update(cterm for cterm,score in tscores)
     # add the term count tab, only for the terms listed in the fscore/precision/recall parts
     wpart += draw_ontology_score_list(term_count, section_id='term_count', description='Number of experiments containing the term',term_set=tterms)

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -2688,7 +2688,7 @@ def get_close_sequences(sequence, max_mismatches = 2):
     httpResTax = requests.get(dbbact_server_address + '/sequences/get_close_sequences', json=rdata)
     if httpResTax.status_code == requests.codes.ok:
         res = httpResTax.json()
-        debug(2, 'Found %d close sequences' % len(res['sequences']))
+        debug(2, 'Found %d close sequences' % len(res['similar_seqs']))
         return res['similar_seqs']
     debug('error encountered when trying to get close sequences for sequence %s' % sequence)
     return []

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -602,12 +602,13 @@ def sequence_annotations(sequence):
     # Create the results page
     # the sequence info part, with species details
     webPage = render_header(title='dbBact sequence annotation')
-    webPage += render_template('seqinfo.html', sequence=sequence.upper(), taxonomy=taxStr, species_details=species_details, num_species_match=num_species_match)
 
     if found_only_mismatch:
         webPage += '<h2>Exact sequence was not found in dbBact</h2>'
         webPage += '<p>However, a single sequence with a high similarity to your sequence was found in dbBact. '
         webPage += 'Showing results for this sequence</p>'
+
+    webPage += render_template('seqinfo.html', sequence=sequence.upper(), taxonomy=taxStr, species_details=species_details, num_species_match=num_species_match)
 
     if show_trim_msg:
         if found_seq:

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -2379,7 +2379,8 @@ def draw_group_annotation_details(annotations, seqannotations, term_info, includ
     wpart += cpart
     tterms.update(cterm for cterm,score in tscores)
     # add the term count tab, only for the terms listed in the fscore/precision/recall parts
-    wpart += draw_ontology_score_list(term_count, section_id='term_count', description='Number of experiments containing the term',term_set=tterms)
+    cpart, tscores += draw_ontology_score_list(term_count, section_id='term_count', description='Number of experiments containing the term',term_set=tterms)
+    wpart += cpart
 
     # draw the annotation table
     # first we need to sort the annotations by total sequences from submitted list in each annotation

--- a/dbbact_website/Site_Main_Flask.py
+++ b/dbbact_website/Site_Main_Flask.py
@@ -2666,7 +2666,7 @@ def get_close_sequences(sequence, max_mismatches = 2):
     httpResTax = requests.get(dbbact_server_address + '/sequences/get_close_sequences', json=rdata)
     if httpResTax.status_code == requests.codes.ok:
         res = httpResTax.json()
-        debug(2, 'Found %d close sequences' % len(res['sequences'])
+        debug(2, 'Found %d close sequences' % len(res['sequences']))
         return res['sequences']
     debug('error encountered when trying to get close sequences for sequence %s' % sequence)
     return []

--- a/dbbact_website/templates/annottable.html
+++ b/dbbact_website/templates/annottable.html
@@ -22,8 +22,9 @@
         <th>Description</th>
         <th>Date</th>
         <th>Region</th>
-        <th>Flag</th>
         <th>Sequences</th>
+        <th>Status</th>
+        <th>Flag</th>
       </tr>
     </thead>
     <tbody>

--- a/dbbact_website/templates/annottable.html
+++ b/dbbact_website/templates/annottable.html
@@ -23,7 +23,7 @@
         <th>Date</th>
         <th>Region</th>
         <th>Sequences</th>
-        <th>Status</th>
+        <th data-original-title="batata" data-toggle="tooltip" data-placement="bottom">Status</th>
         <th>Flag</th>
       </tr>
     </thead>

--- a/dbbact_website/templates/annottable.html
+++ b/dbbact_website/templates/annottable.html
@@ -23,7 +23,7 @@
         <th>Date</th>
         <th>Region</th>
         <th>Sequences</th>
-        <th data-original-title="batata" data-toggle="tooltip" data-placement="bottom">Status</th>
+        <th >Status</th>
         <th>Flag</th>
       </tr>
     </thead>

--- a/dbbact_website/templates/seq-list-collapse.html
+++ b/dbbact_website/templates/seq-list-collapse.html
@@ -1,0 +1,48 @@
+<style>
+  #tax-panel {
+    margin-left: 100px;
+    margin-right: 100px;
+  }
+  #tax-box {
+    padding: 20px;
+    overflow: auto;
+    font-size: 20px;
+  }
+
+ </style>
+
+<div id="seqlist-panel" class="panel panel-default">
+  <div class="panel-heading">
+    Sequences list:
+  </div>
+
+  <div id="seqlist-box" class="panel-body">
+    Total sequences : {{seq_count}}
+    <br>
+    <button id="collapse-btn" data-toggle="collapse" data-target="#seqlist">Show sequences</button>
+    <br>
+    <div id="seqlist" class="collapse">
+      <table id="seq-list-seq-list-tbl" class="table responsive" style="width: 100%;">
+      <thead>
+        <tr>
+          <th>Sequence</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{ details | safe}}
+      </tbody>
+    </table>
+    </div>
+  </div>
+</div>
+
+
+<script type="text/javascript">
+  $(document).ready(function() {
+    $('#seq-list-seq-list-tbl').DataTable({'scrollX': true, 'autoWidth': true, 'paging': true, 'lengthMenu':[10, 25, 50, 100, -1], 'pageLength': 10, 'aaSorting': []});
+} );
+
+$('#seqlist').on('shown.bs.collapse', function() {
+   $('#seq-list-seq-list-tbl').DataTable().columns.adjust().draw();
+ });
+</script>

--- a/dbbact_website/templates/seq-list-collapse.html
+++ b/dbbact_website/templates/seq-list-collapse.html
@@ -26,6 +26,7 @@
       <thead>
         <tr>
           <th>Sequence</th>
+          <th>Mismatches</th>
         </tr>
       </thead>
       <tbody>

--- a/dbbact_website/templates/seq-list-collapse.html
+++ b/dbbact_website/templates/seq-list-collapse.html
@@ -13,7 +13,7 @@
 
 <div id="seqlist-panel" class="panel panel-default">
   <div class="panel-heading">
-    Sequences list:
+    {{ title }}:
   </div>
 
   <div id="seqlist-box" class="panel-body">

--- a/dbbact_website/templates/tabs.html
+++ b/dbbact_website/templates/tabs.html
@@ -4,5 +4,6 @@
     <li><a data-toggle="tab" href="#fscores">F-Scores</a></li>
     <li><a data-toggle="tab" href="#recall">Recall</a></li>
     <li><a data-toggle="tab" href="#precision">Precision</a></li>
+    <li><a data-toggle="tab" href="#term_count">Term reliability</a></li>
   </ul>
   <div class="tab-content">


### PR DESCRIPTION
* Add inexact sequence matching (up to 2 mismatches) when not finding exact sequence
* Add review_status column for annotation info table (shows if annotation was reviewed by the dbBact team)
* Add per-term reliability table next to f-score/recall/precision tables (showing in how many experiments the term is associated with the sequence)